### PR TITLE
Fix regression in check-manifest 0.42: --ignore syntax was changed.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest
     mock
 commands =
-    check-manifest --ignore tox.ini,tests*
+    check-manifest --ignore tox.ini,tests/**
     python setup.py check -m -s
     flake8 .
     black src/ tests/ --check


### PR DESCRIPTION
See the [check-manifest changelog](https://pypi.org/project/check-manifest/#changelog)

![image](https://user-images.githubusercontent.com/62100288/83942272-0c5f9d00-a7ea-11ea-855d-408e4c2b0f4f.png)
